### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Compare The Latest Releases Between Two Repositories
         id: compare-releases
-        uses: NickLiffen/compare-releases@v2.0.4
+        uses: NickLiffen/compare-releases@626496b5cfe13f49d5b79ceeec49ad0170146a67 # v2.0.4
         with:
           destinationRepository: ${{ env.DESTINATION_REPOSITORY }}
           sourceRepository: ${{ env.SOURCE_REPOSITORY }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Invoke Release Workflow
         if: ${{ steps.compare-releases.outputs.repo == env.DESTINATION_REPOSITORY }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
           workflow: release
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron:  '0 * * * *'
 
+permissions:
+  contents: read
+
 env:
   DESTINATION_REPOSITORY: github/codeql-action
   SOURCE_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/codeql-container/security/code-scanning/1](https://github.com/advanced-security/codeql-container/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to restrict the `GITHUB_TOKEN`'s available permissions for this workflow. Since none of the workflow steps require write access to repository contents (they interact with releases and use external actions via tokens), the minimal safe starting point is to set `permissions: contents: read` at the root of the workflow, before the `jobs` block. This makes the workflow explicit and compliant with the principle of least privilege without breaking existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
